### PR TITLE
Create a faux fullscreen mode for iOS

### DIFF
--- a/resources/assets/js/components/course/screens/Slideshow.vue
+++ b/resources/assets/js/components/course/screens/Slideshow.vue
@@ -12,7 +12,11 @@
 				</div>
 			</div>
 			<div class="wnl-screen wnl-ratio-16-9">
-				<div class="wnl-slideshow-content" :class="{ 'is-focused': isFocused }"></div>
+				<div class="wnl-slideshow-content" :class="{ 'is-focused': isFocused, 'is-faux-fullscreen': isFauxFullscreen }">
+					<div class="faux-fullscreen-close" v-if="isFauxFullscreen" @click="closeFauxFullscreen">
+						<span class="icon is-medium"><i class="fa fa-times"></i></span>
+					</div>
+				</div>
 			</div>
 			<div class="wnl-slideshow-controls">
 				<div class="wnl-slideshow-controls-left">
@@ -110,6 +114,7 @@
 				child: {},
 				currentSlide: 1,
 				loaded: false,
+				isFauxFullscreen: false,
 				isFocused: false,
 				slideChanged: false
 			}
@@ -131,6 +136,9 @@
 			slideshowElement() {
 				return this.container.getElementsByTagName('iframe')[0]
 			},
+			slideshowSizeClass() {
+				return this.isFauxFullscreen ? 'is-faux-fullscreen' : 'wnl-ratio-16-9'
+			},
 			iframe() {
 				if (this.loaded) {
 					return this.$el.getElementsByTagName('iframe')[0]
@@ -138,11 +146,17 @@
 			},
 		},
 		methods: {
+			closeFauxFullscreen() {
+				this.isFauxFullscreen = false
+				this.focusSlideshow()
+			},
 			toggleFullscreen() {
 				if (screenfull.enabled) {
 					screenfull.toggle(this.slideshowElement)
-					this.focusSlideshow()
+				} else {
+					this.isFauxFullscreen = true
 				}
+				this.focusSlideshow()
 			},
 			slideNumberFromIndex(index) {
 				return index + 1

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -158,6 +158,32 @@ html, body {
 	top: 0;
 }
 
+.is-faux-fullscreen {
+	bottom: 0 !important;
+	left: 0 !important;
+	position: fixed !important;
+	right: 0 !important;
+	top: 0 !important;
+	transition: all 0.2s;
+	z-index: 16777270; // Almost the highest possible value in Safari
+}
+
+.faux-fullscreen-close {
+	border: 0;
+	background: $color-inactive-gray;
+	border-radius: $border-radius-full;
+	box-sizing: content-box;
+	color: $color-white;
+	cursor: pointer;
+	height: 28px;
+	padding: 10px;
+	position: fixed;
+	right: 1vw;
+	top: 1vh;
+	width: 28px;
+	z-index: 16777271; // The highest possible value in Safari
+}
+
 // Notifications
 .swal2-spacer {
 	background: transparent;


### PR DESCRIPTION
Since Safari and Chrome on iOS do not support [Fullscreen API](http://caniuse.com/#search=fullscreen), I implemented a "faux fullscreen mode", in which the presentation is positioned as fixed on top of everything.

Since the problem only occurs on touch devices, you can close the fullscreen using an x button in top right corner, but the Esc key doesn't work (no need for that).