### PR TITLE
Wrap embed elements in fullwidth container on component update

### DIFF
--- a/resources/assets/js/components/course/screens/Html.vue
+++ b/resources/assets/js/components/course/screens/Html.vue
@@ -69,6 +69,9 @@
 		},
 		mounted() {
 			this.wrapEmbedded()
-		}
+		},
+		updated() {
+			this.wrapEmbedded()
+		},
 	}
 </script>


### PR DESCRIPTION
Without it, if you had more than 1 screen of Html type, only the first iframe is scaled to fullwidth.