### PR TITLE
Mobile UI | PoC of a persisting side nav drawer

### DIFF
--- a/resources/assets/js/components/App.vue
+++ b/resources/assets/js/components/App.vue
@@ -37,8 +37,12 @@
 			//.then(()=>this.setupNotifications())
 		},
 		mounted() {
-			this.$router.afterEach(() => {
-				this.resetLayout()
+			this.$router.afterEach((to) => {
+				to.matched.some((record) => {
+					if (!record.meta.keepsNavOpen) {
+						this.resetLayout()
+					}
+				})
 			})
 
 			this.setLayout(this.$breakpoints.currentBreakpoint())

--- a/resources/assets/js/router.js
+++ b/resources/assets/js/router.js
@@ -75,12 +75,14 @@ if (isProduction()) {
 		{
 			path: '/app/courses/:courseId',
 			component: require('js/components/course/Course.vue'),
+			meta: { keepsNavOpen: true },
 			props: true,
 			children: [
 				{
 					name: resource('courses'),
 					path: '',
 					component: require('js/components/course/Overview.vue'),
+					meta: { keepsNavOpen: true },
 					props: true,
 				},
 				{
@@ -103,8 +105,8 @@ if (isProduction()) {
 			name: 'myself',
 			path: '/app/myself',
 			component: require('js/components/user/Myself.vue'),
+			meta: { keepsNavOpen: true },
 			props: true,
-			redirect: { name: "my-profile" },
 			children: [
 				{
 					name: 'my-orders',
@@ -142,6 +144,7 @@ if (isProduction()) {
 			name: 'collections',
 			path: '/app/collections',
 			component: require('js/components/collections/Collections.vue'),
+			meta: { keepsNavOpen: true },
 			props: true,
 			// redirect: { name: "my-profile" },
 			children: [
@@ -165,7 +168,8 @@ if (isProduction()) {
 		{
 			name: 'dashboard',
 			path: '/app',
-			redirect: { name: 'courses', params: { courseId: 1 } }
+			redirect: { name: 'courses', params: { courseId: 1 } },
+			meta: { keepsNavOpen: true },
 		},
 		{
 			name: 'logout',


### PR DESCRIPTION
It's less than ideal, as the links actually redirect a user away from the page, but allows for a less surprising navigation and allow for quick navigation between lessons.

In short - if a user goes on mobile to a "root route" i.e. Course overview, Collections or Account - the drawer is not closed but remains with a new route navigation.