### PR TITLE
Fix major bugs in first release of Collections

### DIFF
--- a/resources/assets/js/components/collections/Collections.vue
+++ b/resources/assets/js/components/collections/Collections.vue
@@ -57,7 +57,7 @@
 			<div class="collections-placeholder">
 				<span class="icon main"><i class="fa fa-star-o"></i></span>
 				<span class="welcome">Witaj w Kolekcjach!</span>
-				<span>Wybierz temat z menu <span class="icon is-small" v-if="isTouchScreen"><i class="fa fa-bars"></i></span> i przeglądaj zapisane fragmenty kursu</span>
+				<span>Wybierz temat z menu <span class="icon is-small" v-if="isTouchScreen"><i class="fa fa-bars"></i></span> i&nbsp;przeglądaj&nbsp;zapisane&nbsp;fragmenty&nbsp;kursu</span>
 			</div>
 		</div>
 	</div>
@@ -80,10 +80,14 @@
 
 	.collections-placeholder
 		align-items: center
+		color: $color-gray-dimmed
 		display: flex
 		flex-direction: column
+		font-size: $font-size-plus-1
 		height: 100%
+		min-height: 50vh
 		justify-content: center
+		padding: $margin-big
 		text-align: center
 		width: 100%
 
@@ -92,11 +96,9 @@
 			width: $font-size-plus-7
 
 			.fa
-				color: $color-inactive-gray
 				font-size: $font-size-plus-7
 
 		.welcome
-			color: $color-inactive-gray
 			font-size: $font-size-plus-3
 			font-weight: $font-weight-light
 			line-height: $line-height-plus

--- a/resources/assets/js/components/collections/Collections.vue
+++ b/resources/assets/js/components/collections/Collections.vue
@@ -10,7 +10,7 @@
 			</aside>
 		</wnl-sidenav-slot>
 		<div class="wnl-middle wnl-app-layout-main" v-bind:class="{'full-width': isTouchScreen}" v-if="!isLoading">
-			<div class="scrollable-main-container">
+			<div class="scrollable-main-container" v-if="rootCategoryName && categoryName">
 				<div class="collections-header">
 					<div class="collections-breadcrumbs">
 						<div class="breadcrumb">
@@ -54,6 +54,11 @@
 					</div>
 				</div>
 			</div>
+			<div class="collections-placeholder">
+				<span class="icon main"><i class="fa fa-star-o"></i></span>
+				<span class="welcome">Witaj w Kolekcjach!</span>
+				<span>Wybierz temat z menu <span class="icon is-small" v-if="isTouchScreen"><i class="fa fa-bars"></i></span> i przeglądaj zapisane fragmenty kursu</span>
+			</div>
 		</div>
 	</div>
 </template>
@@ -72,6 +77,29 @@
 
 	.full-width
 		width: 100vw
+
+	.collections-placeholder
+		align-items: center
+		display: flex
+		flex-direction: column
+		height: 100%
+		justify-content: center
+		text-align: center
+		width: 100%
+
+		.icon.main
+			height: $font-size-plus-7
+			width: $font-size-plus-7
+
+			.fa
+				color: $color-inactive-gray
+				font-size: $font-size-plus-7
+
+		.welcome
+			color: $color-inactive-gray
+			font-size: $font-size-plus-3
+			font-weight: $font-weight-light
+			line-height: $line-height-plus
 
 	.collections-header
 		border-bottom: $border-light-gray
@@ -293,16 +321,12 @@
 			this.toggleOverlay({source: 'collections', display: true})
 			this.fetchCategories()
 				.then(this.fetchReactions)
-				.then(this.navigateToDefaultCategoryIfNone)
 				.then(this.setupContentForCategory)
 				.then(() => this.toggleOverlay({source: 'collections', display: false}))
 		},
 		watch: {
 			'$route' () {
 				this.categoryName && this.setupContentForCategory()
-			},
-			'isSidenavVisible'(isOpen, wasOpen) {
-				this.isTouchScreen && !isOpen && wasOpen && this.navigateToDefaultCategoryIfNone()
 			}
 		},
 	}

--- a/resources/assets/js/components/collections/Collections.vue
+++ b/resources/assets/js/components/collections/Collections.vue
@@ -197,7 +197,7 @@
 			},
 			panels() {
 				return {
-					slides: 'Prezentacja i pytania',
+					slides: 'Slajdy + pytania',
 					quiz: 'Pytania kontrolne',
 				}
 			},

--- a/resources/assets/js/components/collections/SlidesCarousel.vue
+++ b/resources/assets/js/components/collections/SlidesCarousel.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="wnl-slides-collection">
-		<p class="title is-4">Zapisane slajdy <span v-if="presentableLoaded">({{sortedSlides.length}})</span></p>
-		<div class="slides-carousel-container" v-if="presentableLoaded && sortedSlides.length">
+		<p class="title is-4">Zapisane slajdy <span v-if="slideshowReady">({{sortedSlides.length}})</span></p>
+		<div class="slides-carousel-container" v-if="slideshowReady && sortedSlides.length">
 			<div class="slides-carousel">
 				<div class="slide-thumb" :class="" :key="index" v-for="(slide, index) in sortedSlides" @click="showSlide(index)">
 					<div class="thumb-meta">
@@ -20,21 +20,20 @@
 				</div>
 			</div>
 		</div>
-		<div v-else class="notification has-text-centered">
+		<div v-else-if="slideshowReady" class="notification has-text-centered">
 			W temacie <span class="metadata">{{rootCategoryName}} <span class="icon is-small"><i class="fa fa-angle-right"></i></span> {{categoryName}}</span> nie ma jeszcze zapisanych slajdów. Możesz łatwo to zmienić klikając na <span class="icon is-small"><i class="fa fa-star-o"></i></span> <span class="metadata">ZAPISZ</span> na wybranym slajdzie!
 		</div>
 		<wnl-slideshow
 			ref="slideshow"
-			:class="{
-				'is-not-visible' : !presentableLoaded || sortedSlides.length === 0,
-				'is-folded' : presentableLoaded && sortedSlides.length === 0,
-			}"
+			v-if="!slideshowReady || sortedSlides.length"
+			:class="{'is-not-visible': !slideshowReady}"
 			:screenData="screenData"
 			:presentableId="categoryId"
 			:presentableType="presentableType"
 			:preserveRoute="true"
 			:slideOrderNumber="currentSlideOrderNumber"
 			@slideBookmarked="onSlideBookmarked"
+			@slideshowReady="slideshowReady = true"
 		></wnl-slideshow>
 	</div>
 </template>
@@ -47,10 +46,6 @@
 	$thumb-width: 160px
 
 	.is-not-visible
-		visibility: hidden
-
-	.is-folded
-		height: 0
 		visibility: hidden
 
 	.wnl-slides-collection
@@ -159,11 +154,12 @@
 		props: ['categoryId', 'rootCategoryName', 'categoryName'],
 		data() {
 			return {
-				selectedSlideIndex: null,
+				presentableType: 'App\\Models\\Category',
 				screenData: {
 					type: 'slideshow'
 				},
-				presentableType: 'App\\Models\\Category',
+				selectedSlideIndex: 0,
+				slideshowReady: false,
 			}
 		},
 		components: {
@@ -233,7 +229,10 @@
 		watch: {
 			'categoryId'() {
 				this.selectedSlideIndex = 0
-			}
+			},
+			'categoryName'() {
+				this.slideshowReady = false
+			},
 		}
 	}
 </script>

--- a/resources/assets/js/components/collections/SlidesCarousel.vue
+++ b/resources/assets/js/components/collections/SlidesCarousel.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="wnl-slides-collection">
-		<p class="title is-4">Twoja kolekcja slajdów <span v-if="presentableLoaded">({{sortedSlides.length}})</span></p>
+		<p class="title is-4">Zapisane slajdy <span v-if="presentableLoaded">({{sortedSlides.length}})</span></p>
 		<div class="slides-carousel-container" v-if="presentableLoaded && sortedSlides.length">
 			<div class="slides-carousel">
 				<div class="slide-thumb" :class="" :key="index" v-for="(slide, index) in sortedSlides" @click="showSlide(index)">
@@ -51,6 +51,7 @@
 
 	.is-folded
 		height: 0
+		visibility: hidden
 
 	.wnl-slides-collection
 		margin-top: $margin-base
@@ -158,7 +159,7 @@
 		props: ['categoryId', 'rootCategoryName', 'categoryName'],
 		data() {
 			return {
-				selectedSlideIndex: 0,
+				selectedSlideIndex: null,
 				screenData: {
 					type: 'slideshow'
 				},

--- a/resources/assets/js/components/course/screens/slideshow/Slideshow.vue
+++ b/resources/assets/js/components/course/screens/slideshow/Slideshow.vue
@@ -230,7 +230,10 @@
 				this.focusSlideshow()
 			},
 			focusSlideshow() {
-				if (this.child.hasOwnProperty('frame') && typeof this.child.frame !== undefined) {
+				if (typeof this.child !== 'undefined' &&
+					this.child.hasOwnProperty('frame') &&
+					typeof this.child.frame !== 'undefined'
+				) {
 					this.child.frame.click()
 					this.child.frame.focus()
 				}
@@ -295,11 +298,12 @@
 						this.toggleFullscreen()
 					} else if (event.data.value.name === 'loaded') {
 						this.toggleOverlay({source: 'slideshow', display: false})
-						this.child.call('setupBookmarks', this.bookmarkedSlideNumbers);
+						this.child.call('setupBookmarks', this.bookmarkedSlideNumbers)
+						this.$emit('slideshowReady')
 					} else if (event.data.value.name === 'bookmark') {
-						const slideData = event.data.value.data;
+						const slideData = event.data.value.data
 
-						!this.bookmarkLoading && this.toggleBookmarkedState(slideData.index, slideData.isBookmarked);
+						!this.bookmarkLoading && this.toggleBookmarkedState(slideData.index, slideData.isBookmarked)
 					}
 				}
 			},
@@ -343,7 +347,7 @@
 				this.loaded = false
 			},
 			onAnnotationsUpdated(comments) {
-				if (typeof this.child.call === 'function') {
+				if (typeof this.child !== 'undefined' && typeof this.child.call === 'function') {
 					let annotations = _.cloneDeep(comments)
 
 					if (annotations.length > 0) {

--- a/resources/assets/js/store/modules/comments.js
+++ b/resources/assets/js/store/modules/comments.js
@@ -11,7 +11,9 @@ export const commentsGetters = {
 	 * @param  {Object} commentable { commentable_resource: String, commentable_id: Int }
 	 */
 	comments: (state) => (payload) => {
-		if (!state[payload.resource][payload.id].hasOwnProperty('comments')) {
+		if (typeof state[payload.resource][payload.id] !== 'object' ||
+			!state[payload.resource][payload.id].hasOwnProperty('comments')
+		) {
 			return []
 		}
 


### PR DESCRIPTION
1. Hiding slideshow with no bookmarked slides wasn't working and this allowed people to use Collections to view slideshows not yet available to them.
2. Collections always loaded the first and heaviest category - Cardiology. Slower machines (e.g. iPhone 6s, so not THAT slow) were not able to process it. A simple placeholder was introduced for that reason.