### PR TITLE
Fix displaying nested lists from Quill editor

### DIFF
--- a/resources/assets/sass/_styleguide.scss
+++ b/resources/assets/sass/_styleguide.scss
@@ -272,6 +272,44 @@ button.button {
 	}
 }
 
+.wnl-screen-html {
+	$resets: (
+		'list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+		'list-3 list-4 list-5 list-6 list-7 list-8 list-9',
+		'list-4 list-5 list-6 list-7 list-8 list-9',
+		'list-5 list-6 list-7 list-8 list-9',
+		'list-6 list-7 list-8 list-9',
+		'list-7 list-8 list-9',
+		'list-8 list-9',
+		'list-9'
+	);
+	$list-styles: decimal lower-alpha lower-roman;
+
+	ol li {
+		counter-increment: list-num;
+		counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+		list-style-type: none;
+	}
+
+	ol li:before {
+		content: counter(list-num, decimal) ". ";
+	}
+
+	@for $i from 1 through 8 {
+		$j: $i + 1;
+
+		ol li.ql-indent-#{$i} {
+			counter-increment: list-#{$i};
+			counter-reset: unquote(nth($resets, $i));
+			padding-left: 2 * $margin-base * $i;
+		}
+
+		ol li.ql-indent-#{$i}:before {
+			content: counter(unquote('list-#{$i}'), nth($list-styles, ($i%3+1))) ". ";
+		}
+	}
+}
+
 .ql-indent-1 {
 	margin-left: $margin-base * 1;
 }


### PR DESCRIPTION
The problem origins in Quill not nesting `ol` lists but adding a `.ql-indent-#{$i}` class to every indentation level. If you want to have nested lists that **actually** reset counters, you need to implement Quill editor's styling-style of these lists.