### PR TITLE
Shipping status

### DIFF
--- a/app/Console/Commands/AddressesExport.php
+++ b/app/Console/Commands/AddressesExport.php
@@ -20,6 +20,7 @@ class AddressesExport extends Command
 		{--I|ids= : Comma separated list of ids of orders to export}
 		{--P|products= : Comma separated list of products to export}
 		{--F|from= : A date from which you want the export}
+		{--S|ship= : Should the script mark orders as exported to shipping? Set to 1 to do it.}
 	';
 
 	/**
@@ -49,14 +50,17 @@ class AddressesExport extends Command
 		$products = $this->option('products');
 		$ids = $this->option('ids');
 		$from = $this->option('from');
+		$ship = intval($this->option('ship'));
 
 		if ($ids) {
 			$ids = explode(',', $ids);
 			$orders = Order::where('paid', 1)
+				->where('shipping_status', 'new')
 				->whereIn('id', $ids);
 		} elseif ($products) {
 			$products = explode(',', $products);
 			$orders = Order::where('paid', 1)
+				->where('shipping_status', 'new')
 				->whereIn('product_id', $products);
 		} else {
 			$this->error('Specify IDs or ProductIDs to export orders.');
@@ -65,6 +69,10 @@ class AddressesExport extends Command
 		if ($from) {
 			$from = Carbon::createFromFormat('Y-m-d H:i:s', $from);
 			$orders = $orders->where('created_at', '>', $from);
+		}
+
+		if ($ship===1) {
+			$orders->update(['shipping_status' => 'ordered']);
 		}
 
 		$orders = $orders->get();

--- a/app/Console/Commands/OrdersShippingStatus.php
+++ b/app/Console/Commands/OrdersShippingStatus.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Order;
+use Illuminate\Console\Command;
+
+class OrdersShippingStatus extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'orders:shipping
+		{status : A new status for orders shipping (new, exported or delivered)}
+		{ids : Comma separated list of ids of orders to affect}
+	';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Change shipping status for given orders';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$status = $this->argument('status');
+		$ordersIds = $this->argument('ids');
+
+		if (!$ordersIds || !$status) {
+			$this->error('Order ID or status missing!');
+			$this->info('Usage: php artisan orders:shipping -S {status} -I {IDs}');
+			exit;
+		}
+
+		$idsArray = explode(',', $ordersIds);
+		$orders = Order::with(['user', 'product'])
+			->whereIn('id', $idsArray);
+
+		if (!$orders) {
+			$this->error("Sorry, it seems that there are no orders with given IDs in the database.");
+			exit;
+		}
+
+		if (!$this->confirm("You are about to change a shipping status to `{$status}` for " . count($idsArray) . " orders. Is it right?")) {
+			$this->info('Ok, nevermind. Aborted.');
+			exit;
+		}
+
+		$orders->update(['shipping_status' => $status]);
+		$this->info('Done.');
+
+		return true;
+	}
+}

--- a/app/Console/Commands/OrdersShippingStatus.php
+++ b/app/Console/Commands/OrdersShippingStatus.php
@@ -13,7 +13,7 @@ class OrdersShippingStatus extends Command
 	 * @var string
 	 */
 	protected $signature = 'orders:shipping
-		{status : A new status for orders shipping (new, exported or delivered)}
+		{status : A new status for orders shipping (new, ordered, in_progress, or delivered)}
 		{ids : Comma separated list of ids of orders to affect}
 	';
 
@@ -53,7 +53,7 @@ class OrdersShippingStatus extends Command
 		$orders = Order::with(['user', 'product'])
 			->whereIn('id', $idsArray);
 
-		if (!$orders) {
+		if (!$orders->count()) {
 			$this->error("Sorry, it seems that there are no orders with given IDs in the database.");
 			exit;
 		}

--- a/database/migrations/2018_05_22_112453_add_shipping_status_to_orders_table.php
+++ b/database/migrations/2018_05_22_112453_add_shipping_status_to_orders_table.php
@@ -14,7 +14,7 @@ class AddShippingStatusToOrdersTable extends Migration
     public function up()
     {
         Schema::table('orders', function (Blueprint $table) {
-            $table->string('shipping_status')->default('new');
+            $table->enum('shipping_status', ['new', 'ordered', 'in_progress', 'delivered'])->default('new')->after('shipping');
         });
     }
 

--- a/database/migrations/2018_05_22_112453_add_shipping_status_to_orders_table.php
+++ b/database/migrations/2018_05_22_112453_add_shipping_status_to_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddShippingStatusToOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->string('shipping_status')->default('new');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('shipping_status');
+        });
+    }
+}


### PR DESCRIPTION
The migration creates a new column `shipping_status` in the orders table. The PR also includes a command that allows changing the status for given orders IDs.

TODO:
- [x] Automatically mark `shipping_status` as `ordered`, when it's exported with the `addresses:export` command.