### PR TITLE
Fix notifications private stream

### DIFF
--- a/app/Listeners/Handlers/CommentPostedHandler.php
+++ b/app/Listeners/Handlers/CommentPostedHandler.php
@@ -35,9 +35,11 @@ class CommentPostedHandler
 			$gate->notifyPrivate($user, $event);
 		}
 
-		$excluded->push($commentableAuthor);
+		if ($commentableAuthor) {
+			$excluded->push($commentableAuthor);
+		}
 
-		if ($commentable->comments->count() === 1){
+		if ($commentable->comments->count() === 1) {
 			// Notify only about the first comment
 			$gate->notifyPrivateStream($excluded->pluck('id')->toArray(), $event);
 		}

--- a/app/Listeners/UserNotificationsGate.php
+++ b/app/Listeners/UserNotificationsGate.php
@@ -31,6 +31,10 @@ class UserNotificationsGate implements ShouldQueue
 
 	public function notifyPrivateStream(array $excluded, $event)
 	{
+		$excluded = array_filter($excluded, function($item) {
+			return !is_null($item);
+		});
+
 		$progress = $this->usersLessonProgress($event);
 
 		$users = User::select()

--- a/app/Traits/EventContextTrait.php
+++ b/app/Traits/EventContextTrait.php
@@ -16,7 +16,9 @@ trait EventContextTrait {
 							'resource' => 'qna_questions',
 							'value' => $model->id,
 						],
-						'route' => $model->meta['context']
+						'route' => $model->meta['context'],
+						// params are used to determine if user already started a lesson from QnaQuestion context
+						'params' => $model->meta['context']['params']
 					];
 				}
 

--- a/app/Traits/EventContextTrait.php
+++ b/app/Traits/EventContextTrait.php
@@ -18,7 +18,7 @@ trait EventContextTrait {
 						],
 						'route' => $model->meta['context'],
 						// params are used to determine if user already started a lesson from QnaQuestion context
-						'params' => $model->meta['context']['params']
+						'params' => $model->meta['context']['params'] ?? []
 					];
 				}
 


### PR DESCRIPTION
Były 2 problemy:
- notyfikacje o komentarzach do slajdów nie miały prawa działać ponieważ slajdy nie posiadają "commentableAuthor". Bez sprawdzenia czy autor istnieje dorzucaliśmy go do listy "$exluded". Dorzucenie tam null powodowało że żaden użytkownik nie był zwracany dla User::whereNotIn('id' , $excluded)
- notyfikacje o QnaQuestion ignorowały czy użytkownik rozpoczął daną lekcję ponieważ struktura "contextu" tego eventu jest inna niż innych ze względu na "dynamic context".