### PR TITLE
update command and collections to support lessons with more than one presentation

### DIFF
--- a/app/Console/Commands/SlidesFromCategory.php
+++ b/app/Console/Commands/SlidesFromCategory.php
@@ -15,7 +15,7 @@ class SlidesFromCategory extends Command
 	 *
 	 * @var string
 	 */
-	protected $signature = 'slides:fromCategory';
+	protected $signature = 'slides:fromCategory {categoryId?}';
 
 	/**
 	 * The console command description.
@@ -41,59 +41,69 @@ class SlidesFromCategory extends Command
 	 */
 	public function handle()
 	{
-		$allCategories = Category::all();
-		$bar = $this->output->createProgressBar(count($allCategories));
+		$categoryId = $this->argument('categoryId');
+		$category = Category::find($categoryId);
+		if (!empty($category)) {
+			$this->handleCategory($category);
+		} else {
+			$allCategories = Category::all();
+			$bar = $this->output->createProgressBar(count($allCategories));
 
-		// clean up before start
-		\DB::table('presentables')
-			->where('presentable_type', 'App\Models\Category')
-			->delete();
-
-
-		foreach ($allCategories as $category) {
-
-			$categoryTag = Tag::where('name', $category->name)->first();
-			if (!empty($category->parent_id)) {
-				$lessonsWithTag = Lesson::whereHas('tags', function($tag) use ($categoryTag) {
-					$tag->where('name', $categoryTag->name);
-				})->orderBy('order_number')->get();
-
-
-				$this->attachLessonsSlidesToCategory($lessonsWithTag, $category);
+			foreach ($allCategories as $category) {
+				$this->handleCategory($category);
+				$bar->advance();
 			}
-
-			$bar->advance();
 		}
 
+
 		print PHP_EOL;
+	}
+
+	private function handleCategory($category) {
+		\DB::table('presentables')
+			->where('presentable_type', 'App\Models\Category')
+			->where('presentable_id', $category->id)
+			->delete();
+
+		$categoryTag = Tag::where('name', $category->name)->first();
+		if (!empty($category->parent_id)) {
+			$lessonsWithTag = Lesson::whereHas('tags', function($tag) use ($categoryTag) {
+				$tag->where('name', $categoryTag->name);
+			})->orderBy('order_number')->get();
+
+
+			$this->attachLessonsSlidesToCategory($lessonsWithTag, $category);
+		}
 	}
 
 	private function attachLessonsSlidesToCategory($lessonsWithTag, $category) {
 		$orderNumber = 0;
 
 		foreach($lessonsWithTag as $lesson) {
-			$screen = $lesson->screens()->where('type', 'slideshow')->first();
+			$screens = $lesson->screens()->where('type', 'slideshow')->get();
 
-			if (!$screen) {
+			if ($screens->isEmpty()) {
 				continue;
 			}
 
-			$slidesIds = \DB::table('presentables')
-				->where('presentable_type', 'App\Models\Slideshow')
-				->where('presentable_id', $screen->slideshow->id)
-				->orderBy('order_number')
-				->get(['slide_id'])->pluck('slide_id');
+			foreach ($screens as $screen) {
+				$slidesIds = \DB::table('presentables')
+					->where('presentable_type', 'App\Models\Slideshow')
+					->where('presentable_id', $screen->slideshow->id)
+					->orderBy('order_number')
+					->get(['slide_id'])->pluck('slide_id');
 
-			foreach($slidesIds as $slideId) {
-				$slide = Slide::find($slideId);
-				try {
-					$category->slides()->attach($slide, ['order_number' => $orderNumber]);
-					$orderNumber++;
-				} catch (\Illuminate\Database\QueryException $e) {
-					if ($e->errorInfo[1] === 1062) {
-						// Means entry is duplicated.
-					} else {
-						throw $e;
+				foreach($slidesIds as $slideId) {
+					$slide = Slide::find($slideId);
+					try {
+						$category->slides()->attach($slide, ['order_number' => $orderNumber]);
+						$orderNumber++;
+					} catch (\Illuminate\Database\QueryException $e) {
+						if ($e->errorInfo[1] === 1062) {
+							// Means entry is duplicated.
+						} else {
+							throw $e;
+						}
 					}
 				}
 			}

--- a/app/Http/Controllers/Api/Concerns/TranslatesApiQueries.php
+++ b/app/Http/Controllers/Api/Concerns/TranslatesApiQueries.php
@@ -159,10 +159,14 @@ trait TranslatesApiQueries
 	protected function applyFilters($model, $request)
 	{
 		$query = $this->parseTime($request->get('query'));
+		$select = $request->get('select');
 		$order = $request->get('order');
 		$limit = $request->get('limit');
 		$join = $request->get('join');
 
+		if (!empty($select)) {
+			$model->select($select);
+		}
 		$model = $this->parseQuery($model, $query);
 
 		if (!empty ($order)) {

--- a/resources/assets/js/store/modules/collections.js
+++ b/resources/assets/js/store/modules/collections.js
@@ -109,18 +109,19 @@ const actions = {
 	},
 	fetchSlidesByTagName({commit}, {tagName, ids}) {
 		commit(types.SLIDES_LOADING, true);
-		return axios.post(getApiUrl('slides/.search'), {
+		return axios.post(getApiUrl('slides/.query'), {
+			select: ['slides.*'],
 			query: {
 				whereHas: {
 					tags: {
 						where: [['tags.name', '=', tagName]]
 					}
 				},
-				whereIn: ['id', ids],
+				whereIn: ['slides.id', ids],
+				where: [['presentables.presentable_type', 'App\\Models\\Category']]
 			},
-			order: {
-				id: 'desc',
-			},
+			join: [['presentables', 'slides.id', '=', 'presentables.slide_id']],
+			order: {'presentables.order_number': 'asc'}
 		}).then(({data}) => {
 			commit(types.COLLECTIONS_SET_SLIDES, data)
 			commit(types.SLIDES_LOADING, false);


### PR DESCRIPTION
Problem:
- Medycyna Rodzinna 3 ma 2 prezentacje ale obecny skrypt do budowania prezentacji dla kategorii wspierał tylko jeden screen typu slideshow (zawsze pierwszy)

Rozwiązanie:
- poprawienie skryptu żeby brał pod uwagę wszystkie prezentacje z lekcji tworząc prezentację dla kategorii
- poprawienie skryptu żeby można było go uruchomić tylko dla jednej kategorii
- zwracane slajdy w widoku kolekcji są posegregowane wg order_number w prezentacji kategorii zamiast po slide id