### PR TITLE
Do not track all page views on platform to avoid confusion with the website

### DIFF
--- a/resources/views/tracking.blade.php
+++ b/resources/views/tracking.blade.php
@@ -66,7 +66,6 @@
 		s.parentNode.insertBefore(t,s)}(window, document,'script',
 		'https://connect.facebook.net/en_US/fbevents.js');
 	fbq('init', {{ env('FACEBOOK_PIXEL_APP_ID') }});
-	fbq('track', 'PageView');
 </script>
 <noscript><img height="1" width="1" style="display:none"
 	src={{ "https://www.facebook.com/tr?id=" . env('FACEBOOK_PIXEL_APP_ID') . "&ev=PageView&noscript=1" }}


### PR DESCRIPTION
As it turns out, facebook does not allow to easily differentiate between pageviews from multiple sources.

To make it easier for now to use the fb analytics, I removed tracking all pageviews from platform and only kept custom events.