### PR TITLE
Wait for dependencies before starting containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,13 +41,17 @@ services:
     volumes:
       - ${LOCAL_CODE_PATH}:/code
     command: /code/bethink/wnl-platform/artisan queue:work --queue=default --tries=3 --daemon
+    depends_on:
+      - redis
 
   laravel-queue-worker:
-      container_name: laravel-queue-worker
-      image: bethink/php:7.2.7-fpm-alpine3.7
-      volumes:
-        - ${LOCAL_CODE_PATH}:/code
-      command: /code/bethink/wnl-platform/artisan queue:work --queue=notifications --tries=3 --daemon
+    container_name: laravel-queue-worker
+    image: bethink/php:7.2.7-fpm-alpine3.7
+    volumes:
+      - ${LOCAL_CODE_PATH}:/code
+    command: /code/bethink/wnl-platform/artisan queue:work --queue=notifications --tries=3 --daemon
+    depends_on:
+      - redis
 
   composer:
     container_name: composer
@@ -83,6 +87,9 @@ services:
     command: node /code/bethink/wnl-chat/server.js
     ports:
       - "9663:9663"
+    depends_on:
+      - rabbit
+      - redis
 
   sad:
       container_name: sad


### PR DESCRIPTION
I got the following errors when using `docker-compose up`:
```
chat                    | Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED 127.0.0.1:6379
chat                    |     at Object._errnoException (util.js:1022:11)
chat                    |     at _exceptionWithHostPort (util.js:1044:20)
chat                    |     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1198:14)
```
```
chat                    | 2018-12-03T17:47:28.182Z error: connect ECONNREFUSED 127.0.0.1:5672
chat                    | Stack: Error: connect ECONNREFUSED 127.0.0.1:5672
chat                    |     at Object._errnoException (util.js:1022:11)
chat                    |     at _exceptionWithHostPort (util.js:1044:20)
chat                    |     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1198:14) 
```
```
laravel-queue-worker    | In AbstractConnection.php line 155:
laravel-queue-worker    |   Connection refused [tcp://172.18.0.1:6379]  
```
```
laravel-worker          | In AbstractConnection.php line 155:
laravel-worker          |   Connection refused [tcp://172.18.0.1:6379]  
```

Let's use `depends_on` to set the containers startup order.