### PR TITLE
enable custom directory structure inside docker containers

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,14 +33,15 @@ services:
     ports:
       - "9000:9000"
     volumes:
-      - ${LOCAL_CODE_PATH}:/code
+      - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
+    working_dir: ${CONTAINER_CODE_PATH}/wnl-platform
 
   laravel-worker:
     container_name: laravel-worker
     image: bethink/php:7.2.7-fpm-alpine3.7
     volumes:
-      - ${LOCAL_CODE_PATH}:/code
-    command: /code/bethink/wnl-platform/artisan queue:work --queue=default --tries=3 --daemon
+      - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
+    command: ${CONTAINER_CODE_PATH}/wnl-platform/artisan queue:work --queue=default --tries=3 --daemon
     depends_on:
       - redis
 
@@ -48,8 +49,8 @@ services:
     container_name: laravel-queue-worker
     image: bethink/php:7.2.7-fpm-alpine3.7
     volumes:
-      - ${LOCAL_CODE_PATH}:/code
-    command: /code/bethink/wnl-platform/artisan queue:work --queue=notifications --tries=3 --daemon
+      - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
+    command: ${CONTAINER_CODE_PATH}/wnl-platform/artisan queue:work --queue=notifications --tries=3 --daemon
     depends_on:
       - redis
 
@@ -60,7 +61,7 @@ services:
     command: php -a
     tty: true
     volumes:
-      - ${LOCAL_CODE_PATH}:/code
+      - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
 
   echo:
     container_name: echo
@@ -68,7 +69,7 @@ services:
     ports:
       - "8755:8755"
     volumes:
-      - ${LOCAL_CODE_PATH}/bethink/wnl-platform/laravel-echo-server.json:/src/laravel-echo-server.json:ro
+      - ${LOCAL_CODE_PATH}/wnl-platform/laravel-echo-server.json:/src/laravel-echo-server.json:ro
 
   nginx:
     container_name: nginx
@@ -77,26 +78,28 @@ services:
       - "80:80"
     volumes:
       - ${LOCAL_DEV_PATH}/nginx/:/etc/nginx/conf.d:ro
-      - ${LOCAL_CODE_PATH}:/code
+      - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
 
   chat:
     container_name: chat
     image: node:8.11.1-alpine
     volumes:
-      - ${LOCAL_CODE_PATH}:/code
-    command: node /code/bethink/wnl-chat/server.js
+      - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
+    command: node ${CONTAINER_CODE_PATH}/wnl-chat/server.js
     ports:
       - "9663:9663"
     depends_on:
       - rabbit
       - redis
+    working_dir: ${CONTAINER_CODE_PATH}/wnl-chat
 
   sad:
       container_name: sad
       image: node:8.11.1-alpine
       volumes:
-        - ${LOCAL_CODE_PATH}:/code
-      command: node /code/bethink/sad-server/server.js
+        - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
+      command: node ${CONTAINER_CODE_PATH}/sad-server/server.js
+      working_dir: ${CONTAINER_CODE_PATH}/sad-server
       ports:
         - "1199:1199"
 


### PR DESCRIPTION
Instead of creating directory structure on our local machine that will match the docker-compose configuration I would like to propose to make the paths configurable via env variable.

For instance for directory structure:
```
- home/
-- user/
--- git/
---- bethink/
----- wnl-platform
----- wnl-chat
----- wnl-sad-server
--- data/
---- bethink/
----- nginx/
----- mysql/
```

The possible values for env variables are:
```
LOCAL_CODE_PATH=/home/user/git/bethink
LOCAL_DEV_PATH=/home/user/data/bethink
CONTAINER_CODE_PATH=/code/bethink/
```

After merging this PR make sure you have following changes:
- updated the `platform.conf` file for nginx
- added `CONTAINER_CODE_PATH` environment variable in `wnl-platform/.env` file
