### PR TITLE
PLAT-796 | Track dashboard news events

### DIFF
--- a/resources/assets/js/admin/components/dashboardNews/DashboardNewsEdit.vue
+++ b/resources/assets/js/admin/components/dashboardNews/DashboardNewsEdit.vue
@@ -11,6 +11,12 @@
 		>
 			<wnl-text name="slug">Tytuł</wnl-text>
 			<wnl-textarea name="message">Treść</wnl-textarea>
+			<p class="message-links-info">
+				Jeżeli chcesz umieścić link do strony wewnątrz platformy, użyj relatywnego adresu.
+				Na przykład: <code>/app/courses/1</code> zamiast <code>https://platforma.wiecejnizlek.pl/app/courses/1</code>.
+				Pamiętaj o ukośniku <code>/</code> na początku adresu!
+				Dzięki temu strona otworzy się szybciej i bez przeładowania strony.
+			</p>
 			<p>Możesz użyć następujących parametrów:</p>
 			<ul class="message-arguments">
 				<li
@@ -37,6 +43,9 @@
 <style lang="sass" scoped>
 	.notification
 		max-width: 900px
+
+	.message-links-info
+		margin-bottom: 10px
 
 	.message-arguments
 		list-style: disc

--- a/resources/assets/js/components/course/dashboard/DashboardNews.vue
+++ b/resources/assets/js/components/course/dashboard/DashboardNews.vue
@@ -4,13 +4,14 @@
 			:message="dashboardNews.message"
 			:messageArguments="messageArguments"
 			:slug="dashboardNews.slug"
-			@onClose="seenCurrentNews"
+			@onClose="closed"
+			@onContentClick="contentClicked"
 	/>
 </template>
 
 <script>
-	import store from 'js/services/messagesStore';
 	import {mapGetters} from 'vuex';
+	import store from 'js/services/messagesStore';
 	import WnlDashboardNewsContent from 'js/components/course/dashboard/DashboardNewsContent';
 	import dashboardNewsMessageArguments from 'js/mixins/dashboard-news-message-arguments';
 
@@ -26,7 +27,6 @@
 			WnlDashboardNewsContent
 		},
 		computed: {
-			...mapGetters(['currentUserName', 'hasRole']),
 			...mapGetters('siteWideMessages', ['dashboardNews']),
 			hasSeenNews() {
 				return !!store.get(this.newsStoreKey);
@@ -36,9 +36,43 @@
 			},
 		},
 		methods: {
-			seenCurrentNews() {
+			closed() {
 				this.showNews = false;
 				store.set(this.newsStoreKey, true);
+			},
+			contentClicked({target}) {
+				const href = target.getAttribute('href');
+
+				if (target && href) {
+					if (/^https?:\/\//.test(href)) {
+						// External links always open in a new tab
+						event.preventDefault();
+						window.open(target.href);
+					} else {
+						// Internal links
+						const { altKey, ctrlKey, metaKey, shiftKey, button, defaultPrevented } = event;
+
+						// don't handle with control keys
+						if (metaKey || altKey || ctrlKey || shiftKey) return;
+						// don't handle when preventDefault called
+						if (defaultPrevented) return;
+						// don't handle right clicks
+						if (button !== undefined && button !== 0) return;
+						// don't handle if `target="_blank"`
+						if (target && target.getAttribute) {
+							const linkTarget = target.getAttribute('target');
+							if (/\b_blank\b/i.test(linkTarget)) return;
+						}
+						// don't handle same page links/anchors
+						const url = new URL(target.href);
+						const to = url.pathname;
+
+						if (window.location.pathname !== to) {
+							event.preventDefault();
+							this.$router.push(to);
+						}
+					}
+				}
 			},
 		},
 		mounted() {

--- a/resources/assets/js/components/course/dashboard/DashboardNews.vue
+++ b/resources/assets/js/components/course/dashboard/DashboardNews.vue
@@ -14,6 +14,7 @@
 	import store from 'js/services/messagesStore';
 	import WnlDashboardNewsContent from 'js/components/course/dashboard/DashboardNewsContent';
 	import dashboardNewsMessageArguments from 'js/mixins/dashboard-news-message-arguments';
+	import context from 'js/consts/events_map/context.json';
 
 	export default {
 		name: 'DashboardNews',
@@ -37,6 +38,7 @@
 		},
 		methods: {
 			closed() {
+				this.track(context.dashboard.features.news_message.actions.close.value);
 				this.showNews = false;
 				store.set(this.newsStoreKey, true);
 			},
@@ -44,6 +46,8 @@
 				const href = target.getAttribute('href');
 
 				if (target && href) {
+					this.track(context.dashboard.features.news_message.actions.click_link.value);
+
 					if (/^https?:\/\//.test(href)) {
 						// External links always open in a new tab
 						event.preventDefault();
@@ -74,9 +78,21 @@
 					}
 				}
 			},
+			track(action) {
+				this.$trackUserEvent({
+					feature: context.dashboard.features.news_message.value,
+					action,
+					target: this.dashboardNews.id,
+					context: context.dashboard.value,
+				});
+			},
 		},
 		mounted() {
 			this.showNews = this.dashboardNews && !this.hasSeenNews;
+
+			if (this.showNews) {
+				this.track(context.dashboard.features.news_message.actions.open.value);
+			}
 		},
 	}
 </script>

--- a/resources/assets/js/components/course/dashboard/DashboardNews.vue
+++ b/resources/assets/js/components/course/dashboard/DashboardNews.vue
@@ -21,6 +21,7 @@
 		mixins: [dashboardNewsMessageArguments],
 		data() {
 			return {
+				featureContext: context.dashboard.features.news_message,
 				showNews: false
 			};
 		},
@@ -38,7 +39,7 @@
 		},
 		methods: {
 			closed() {
-				this.track(context.dashboard.features.news_message.actions.close.value);
+				this.track(this.featureContext.actions.close.value);
 				this.showNews = false;
 				store.set(this.newsStoreKey, true);
 			},
@@ -46,7 +47,7 @@
 				const href = target.getAttribute('href');
 
 				if (target && href) {
-					this.track(context.dashboard.features.news_message.actions.click_link.value);
+					this.track(this.featureContext.actions.click_link.value);
 
 					if (/^https?:\/\//.test(href)) {
 						// External links always open in a new tab
@@ -80,7 +81,7 @@
 			},
 			track(action) {
 				this.$trackUserEvent({
-					feature: context.dashboard.features.news_message.value,
+					feature: this.featureContext.value,
 					action,
 					target: this.dashboardNews.id,
 					context: context.dashboard.value,
@@ -91,7 +92,7 @@
 			this.showNews = this.dashboardNews && !this.hasSeenNews;
 
 			if (this.showNews) {
-				this.track(context.dashboard.features.news_message.actions.open.value);
+				this.track(this.featureContext.actions.open.value);
 			}
 		},
 	}

--- a/resources/assets/js/components/course/dashboard/DashboardNewsContent.vue
+++ b/resources/assets/js/components/course/dashboard/DashboardNewsContent.vue
@@ -2,7 +2,7 @@
 	<div class="notification content">
 		<button class="delete" @click="$emit('onClose')"></button>
 		<p class="has-text-centered"><strong v-html="slug"></strong></p>
-		<span v-html="parsedMessage"></span>
+		<span v-html="parsedMessage" @click="$emit('onContentClick', $event)"></span>
 	</div>
 </template>
 

--- a/resources/assets/js/components/course/dashboard/NextLesson.vue
+++ b/resources/assets/js/components/course/dashboard/NextLesson.vue
@@ -129,7 +129,7 @@
 			trackNextLessonClick() {
 				this.$trackUserEvent({
 					feature: context.dashboard.features.next_lesson.value,
-					actions: context.dashboard.features.next_lesson.actions.click_link.value,
+					action: context.dashboard.features.next_lesson.actions.click_link.value,
 					target: this.nextLesson.id,
 					context: context.dashboard.value,
 				})

--- a/resources/assets/js/components/notifications/feeds/stream/StreamNotification.vue
+++ b/resources/assets/js/components/notifications/feeds/stream/StreamNotification.vue
@@ -278,7 +278,7 @@
 				const lessonId = _.get(this.routeContext, 'params.lessonId');
 				const payload = {
 					feature: context.dashboard.features.news_feed.value,
-					actions: context.dashboard.features.news_feed.actions.click_link.value,
+					action: context.dashboard.features.news_feed.actions.click_link.value,
 					context: context.dashboard.value,
 				}
 

--- a/resources/assets/js/components/questions/QuestionsPlanner.vue
+++ b/resources/assets/js/components/questions/QuestionsPlanner.vue
@@ -513,7 +513,7 @@
 			this.$trackUserEvent({
 				feature: features.quiz_planner.value,
 				context: context.questions_bank.value,
-				actions: features.quiz_planner.actions.open.value
+				action: features.quiz_planner.actions.open.value
 			})
 			this.getPlan().then(plan => {
 				isEmpty(plan) ? this.setupPlanner() : this.fetchDynamicFilters()

--- a/resources/assets/js/consts/events_map/context.json
+++ b/resources/assets/js/consts/events_map/context.json
@@ -29,6 +29,20 @@
             "value": "click_link"
           }
         }
+      },
+      "news_message": {
+        "value": "news_message",
+        "actions": {
+          "click_link": {
+            "value": "click_link"
+          },
+          "open": {
+            "value": "open"
+          },
+          "close": {
+            "value": "close"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
https://bethink.atlassian.net/browse/PLAT-796

- Use https://dennisreimann.de/articles/delegating-html-links-to-vue-router.html to open relative URLs without reloading the page
- Track open, close and click_link in dashboard news
- Fix events which were using `actions` instead of `action`