### PR TITLE
Fix loading state for questions on Collections

### DIFF
--- a/resources/assets/js/store/modules/quiz.js
+++ b/resources/assets/js/store/modules/quiz.js
@@ -440,6 +440,7 @@ const actions = {
 
 	resetState({state, commit}) {
 		commit(types.QUIZ_RESET_PROGRESS);
+		commit(types.QUIZ_IS_LOADED, false);
 		commit(types.QUIZ_SET_PAGINATION, {page: 1, last_page: 1});
 	},
 

--- a/resources/assets/js/store/modules/quiz.js
+++ b/resources/assets/js/store/modules/quiz.js
@@ -440,7 +440,7 @@ const actions = {
 
 	resetState({state, commit}) {
 		commit(types.QUIZ_RESET_PROGRESS);
-		commit(types.QUIZ_IS_LOADED, false);
+		commit(types.QUIZ_IS_LOADED, true);
 		commit(types.QUIZ_SET_PAGINATION, {page: 1, last_page: 1});
 	},
 


### PR DESCRIPTION
We call this method when there are no questions in the collection: https://github.com/bethinkpl/wnl-platform/blob/898c2af1b5301e3ea107b1d97abd7f4f42f72fde/resources/assets/js/components/collections/Collections.vue#L277