### PR TITLE
PLAT-897 | Fix styles for .icon class by not leaking text button styles

### DIFF
--- a/resources/assets/js/components/global/TextButton.vue
+++ b/resources/assets/js/components/global/TextButton.vue
@@ -9,7 +9,7 @@
 	</button>
 </template>
 
-<style lang="sass">
+<style lang="sass" scoped>
 	@import 'resources/assets/sass/variables'
 
 	.wnl-text-button


### PR DESCRIPTION
https://bethink.atlassian.net/browse/PLAT-897

`.icon` class is used a lot and this was leaking:
```
.icon { height: auto }
```