### PR TITLE
PLAT-874 | Double comments

### DIFF
--- a/resources/assets/js/store/modules/comments.js
+++ b/resources/assets/js/store/modules/comments.js
@@ -136,10 +136,9 @@ export const commentsMutations = {
 		Object.keys(commentsResourceObj).forEach(resource => {
 			Object.keys(commentsResourceObj[resource]).forEach(resourceId => {
 				const oldComments = state[resource][resourceId].comments || [];
-				const commentsIds = _.uniq(
-					oldComments
-						.concat(Object.keys(commentsResourceObj[resource][resourceId]))
-						.map(id => id.toString())
+				const commentsIds = _.uniqBy(
+					oldComments.concat(Object.keys(commentsResourceObj[resource][resourceId])),
+					commentId => commentId.toString()
 				);
 				set(state[resource][resourceId], 'comments', commentsIds);
 			});

--- a/resources/assets/js/store/modules/comments.js
+++ b/resources/assets/js/store/modules/comments.js
@@ -136,7 +136,11 @@ export const commentsMutations = {
 		Object.keys(commentsResourceObj).forEach(resource => {
 			Object.keys(commentsResourceObj[resource]).forEach(resourceId => {
 				const oldComments = state[resource][resourceId].comments || [];
-				const commentsIds = _.uniq(oldComments.concat(Object.keys(commentsResourceObj[resource][resourceId])));
+				const commentsIds = _.uniq(
+					oldComments
+						.concat(Object.keys(commentsResourceObj[resource][resourceId]))
+						.map(id => id.toString())
+				);
 				set(state[resource][resourceId], 'comments', commentsIds);
 			});
 		});


### PR DESCRIPTION
When calling _.uniq make sure we are comparing the same types

After adding a comment to a slide with ID `x` we do following operations:
- we add it to comments/comments state
- we push it to slideshow/slides[x]/comments array

The problem was that newly created comment had an ID stored as an integer and the old comments have ids stored as strings in slideshow/slides[x]/comments array

When calling _.uniq method I want to make sure we are compering the same types.


Alternative approach would be to don't concat the old commentable comments with newly fetched ones after slide change. However this method is widely used in many modules and I'm afraid of side effects.