### PR TITLE
PLAT-964 | Fix resetting slides order

### DIFF
--- a/app/Console/Commands/ReorderSections.php
+++ b/app/Console/Commands/ReorderSections.php
@@ -46,7 +46,7 @@ class ReorderSections extends Command
 		foreach ($passedSections as $index => $sectionId) {
 			$section = Section::find($sectionId);
 			$sectionScreen = $section->screen;
-			$sectionSlides = $section->slides;
+			$sectionSlides = $section->slides()->orderBy('order_number')->get();
 			$sortedSlides = $sortedSlides->concat($sectionSlides);
 			$sectionsInstances[] = $section;
 


### PR DESCRIPTION
When we were fetching slides for sections we were taking them in the default Mysql order which isn't the same as `order_number`. We use those screens later to update order in the presentation: https://github.com/bethinkpl/wnl-platform/blob/c27353f3fa225cce9e3ba99dd174f8622681b97d/app/Console/Commands/ReorderSections.php#L98