### PR TITLE
Disable opening mock exam in new tab

### DIFF
--- a/resources/assets/js/components/course/screens/MockExam.vue
+++ b/resources/assets/js/components/course/screens/MockExam.vue
@@ -5,9 +5,9 @@
 			{{this.$t('annotations.mockExamAnnotation')}}
 		</div>
 		<p class="margin vertical has-text-centered">
-			<router-link :to="routeParams" class="button is-primary">
+			<button @click="redirectToExam" class="button is-primary">
 				{{this.$t('questions.nav.mockExam')}}!
-			</router-link>
+			</button>
 		</p>
 	</div>
 </template>
@@ -58,6 +58,9 @@ export default {
 		},
 	},
 	methods: {
+		redirectToExam() {
+			this.$router.push(this.routeParams);
+		},
 		wrapEmbedded() {
 			let iframes = this.$el.getElementsByClassName('ql-video'),
 				wrapperClass = 'ratio-16-9-wrapper';


### PR DESCRIPTION
Motivation:
Remove router-link from link to mocked exam. Without router link user can't open mock exam in new tab.

Why do we want to prevent opening in new tab? Because we pass a lot of props to the exam view and we don't want to loose them, and new tab is a new context.