### PR TITLE
Stop exiting chat-queue-worker when there are no messages to consume

### DIFF
--- a/app/Console/Commands/ProcessChatQueue.php
+++ b/app/Console/Commands/ProcessChatQueue.php
@@ -58,7 +58,9 @@ class ProcessChatQueue extends Command
 				default:
 					$this->dropPayload($payload, $resolver, 'Invalid event!');
 			}
-		});
+		}, [
+			'persistent' => true
+		]);
 
 		$this->info('Exiting.');
 


### PR DESCRIPTION
`Consumer::consume` exits if there are no messages to consume and the `persistent` option isn't set:
https://github.com/bschmitt/laravel-amqp/blob/1a7dfb4498e6a5543d70fddb4e1199c9ab33d267/src/Consumer.php#L32-L34

We don't want to do that, because k8s pod restarts every time it happens.