### PR TITLE
PLAT-1050 | Add default order to slides morphed by presentables

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -10,6 +10,6 @@ class Category extends Model implements WithSlides
 	protected $fillable = ['name', 'parent_id'];
 
 	public function slides() {
-		return $this->morphToMany('\App\Models\Slide', 'presentable');
+		return $this->morphToMany('\App\Models\Slide', 'presentable')->orderBy('order_number');
 	}
 }

--- a/app/Models/Section.php
+++ b/app/Models/Section.php
@@ -20,7 +20,7 @@ class Section extends Model implements WithSlides, WithTags
 	}
 
 	public function slides() {
-		return $this->morphToMany('\App\Models\Slide', 'presentable');
+		return $this->morphToMany('\App\Models\Slide', 'presentable')->orderBy('order_number');
 	}
 
 	public function screen()

--- a/app/Models/Slideshow.php
+++ b/app/Models/Slideshow.php
@@ -17,7 +17,7 @@ class Slideshow extends Model implements WithSlides
 
 	public function slides()
 	{
-		return $this->morphToMany('\App\Models\Slide', 'presentable');
+		return $this->morphToMany('\App\Models\Slide', 'presentable')->orderBy('order_number');
 	}
 
 	public function getBackgroundUrlAttribute()

--- a/app/Models/Subsection.php
+++ b/app/Models/Subsection.php
@@ -20,7 +20,7 @@ class Subsection extends Model implements WithSlides, WithTags
 	}
 
 	public function slides() {
-		return $this->morphToMany('\App\Models\Slide', 'presentable');
+		return $this->morphToMany('\App\Models\Slide', 'presentable')->orderBy('order_number');
 	}
 
 	public function section()


### PR DESCRIPTION
`Slide` model doesn't contain `order_number` column, so we cannot add `OrderByOrderNumberScope` there. It's funny but it works for this case. Unfortunately, it fails when querying `Slide` model directly.
For some reason, Laravel skips `Presentable` model definition when analyzing `morphToMany` relation.

**While testing, make sure to clear cache!**