### PR TITLE
Fix voucher page selectors in browser tests

### DIFF
--- a/resources/views/payment/voucher.blade.php
+++ b/resources/views/payment/voucher.blade.php
@@ -26,11 +26,11 @@
 						@endforeach
 					</div>
 					<div class="o-column__row -textCenter">
-						<button type="submit" class="a-button -big">
+						<button type="submit" class="a-button -big" data-button="voucher-submit">
 							@lang('payment.voucher-submit')
 						</button>
 					</div>
-					<a href="{{ route('payment-account') }}" class="a-linkInText -stormGray -textMinus1 -textCenter">
+					<a href="{{ route('payment-account') }}" class="a-linkInText -stormGray -textMinus1 -textCenter" data-link="voucher-skip">
 						@lang('payment.voucher-skip')
 					</a>
 				</form>

--- a/tests/Browser/Pages/Payment/VoucherPage.php
+++ b/tests/Browser/Pages/Payment/VoucherPage.php
@@ -7,37 +7,37 @@ use Laravel\Dusk\Page as BasePage;
 
 class VoucherPage extends BasePage
 {
-    /**
-     * Get the URL for the page.
-     *
-     * @return string
-     */
-    public function url()
-    {
+	/**
+	 * Get the URL for the page.
+	 *
+	 * @return string
+	 */
+	public function url()
+	{
 		return '/payment/voucher';
-    }
+	}
 
-    /**
-     * Assert that the browser is on the page.
-     *
-     * @param  Browser  $browser
-     * @return void
-     */
-    public function assert(Browser $browser)
-    {
-        $browser->assertPathIs($this->url());
-    }
+	/**
+	 * Assert that the browser is on the page.
+	 *
+	 * @param Browser $browser
+	 * @return void
+	 */
+	public function assert(Browser $browser)
+	{
+		$browser->assertPathIs($this->url());
+	}
 
-    /**
-     * Get the element shortcuts for the page.
-     *
-     * @return array
-     */
-    public function elements()
-    {
-        return [
-            '@skip' => '.voucher-skip a',
-			'@use' => '.button'
-        ];
-    }
+	/**
+	 * Get the element shortcuts for the page.
+	 *
+	 * @return array
+	 */
+	public function elements()
+	{
+		return [
+			'@skip' => '[data-link="voucher-skip"]',
+			'@use' => '[data-button="voucher-submit"]'
+		];
+	}
 }


### PR DESCRIPTION
```
...E..EEEE...                                                     13 / 13 (100%)

Time: 2.72 minutes, Memory: 40.00 MB

There were 5 errors:

1) Tests\Browser\Tests\Payment\PaymentTest::testLogInEditDataAndOrder
Facebook\WebDriver\Exception\NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"body .voucher-skip a"}

...
```