### PR TITLE
PLAT-1239 | Use CORS middleware in products list API

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,8 +2,29 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\AccountStatus;
+use App\Http\Middleware\Admin;
+use App\Http\Middleware\ApiAuth;
 use App\Http\Middleware\CheckIfAppUnavailableMode;
+use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\PaymentAuth;
+use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\RedirectIfPaid;
+use App\Http\Middleware\SignupsOpen;
+use App\Http\Middleware\Subscription;
+use App\Http\Middleware\TermsOfUse;
+use App\Http\Middleware\VerifyCsrfToken;
+use Barryvdh\Cors\HandleCors;
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
+use Illuminate\Auth\Middleware\Authorize;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class Kernel extends HttpKernel
 {
@@ -15,7 +36,7 @@ class Kernel extends HttpKernel
 	 * @var array
 	 */
 	protected $middleware = [
-		\Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+		CheckForMaintenanceMode::class,
 	];
 
 	/**
@@ -25,28 +46,29 @@ class Kernel extends HttpKernel
 	 */
 	protected $middlewareGroups = [
 		'web' => [
-			\App\Http\Middleware\EncryptCookies::class,
-			\Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-			\Illuminate\Session\Middleware\StartSession::class,
-			\Illuminate\View\Middleware\ShareErrorsFromSession::class,
-			\App\Http\Middleware\VerifyCsrfToken::class,
-			\Illuminate\Routing\Middleware\SubstituteBindings::class,
+			EncryptCookies::class,
+			AddQueuedCookiesToResponse::class,
+			StartSession::class,
+			ShareErrorsFromSession::class,
+			VerifyCsrfToken::class,
+			SubstituteBindings::class,
 		],
 
 		'api' => [
 			'throttle:60,1',
 			'bindings',
+			HandleCors::class,
 		],
 
 		'hooks' => [],
 
 		'papi' => [
-			\App\Http\Middleware\EncryptCookies::class,
-			\Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-			\Illuminate\Session\Middleware\StartSession::class,
-			\Illuminate\View\Middleware\ShareErrorsFromSession::class,
-			\App\Http\Middleware\VerifyCsrfToken::class,
-			\Illuminate\Routing\Middleware\SubstituteBindings::class,
+			EncryptCookies::class,
+			AddQueuedCookiesToResponse::class,
+			StartSession::class,
+			ShareErrorsFromSession::class,
+			VerifyCsrfToken::class,
+			SubstituteBindings::class,
 		],
 	];
 
@@ -58,29 +80,28 @@ class Kernel extends HttpKernel
 	 * @var array
 	 */
 	protected $routeMiddleware = [
-		'auth'         => \Illuminate\Auth\Middleware\Authenticate::class,
-		'admin'        => \App\Http\Middleware\Admin::class,
-		'payment-auth' => \App\Http\Middleware\PaymentAuth::class,
-		'auth.basic'   => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-		'bindings'     => \Illuminate\Routing\Middleware\SubstituteBindings::class,
-		'can'          => \Illuminate\Auth\Middleware\Authorize::class,
-		'guest'        => \App\Http\Middleware\RedirectIfAuthenticated::class,
-		'throttle'     => \Illuminate\Routing\Middleware\ThrottleRequests::class,
-		'payment'      => \App\Http\Middleware\RedirectIfPaid::class,
-		'signups-open' => \App\Http\Middleware\SignupsOpen::class,
-		'api-auth'     => \App\Http\Middleware\ApiAuth::class,
-		'subscription' => \App\Http\Middleware\Subscription::class,
-		'terms'        => \App\Http\Middleware\TermsOfUse::class,
-		'account-status' => \App\Http\Middleware\AccountStatus::class,
+		'auth' => Authenticate::class,
+		'admin' => Admin::class,
+		'payment-auth' => PaymentAuth::class,
+		'auth.basic' => AuthenticateWithBasicAuth::class,
+		'bindings' => SubstituteBindings::class,
+		'can' => Authorize::class,
+		'guest' => RedirectIfAuthenticated::class,
+		'throttle' => ThrottleRequests::class,
+		'payment' => RedirectIfPaid::class,
+		'signups-open' => SignupsOpen::class,
+		'api-auth' => ApiAuth::class,
+		'subscription' => Subscription::class,
+		'terms' => TermsOfUse::class,
+		'account-status' => AccountStatus::class,
 	];
 
-	public function bootstrap() {
-
+	public function bootstrap()
+	{
 		parent::bootstrap();
 
 		if ($this->app->environment() == 'demo') {
 			$this->pushMiddleware(CheckIfAppUnavailableMode::class);
 		}
-
 	}
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -55,9 +55,7 @@ class Kernel extends HttpKernel
 		],
 
 		'api' => [
-			'throttle:60,1',
 			'bindings',
-			HandleCors::class,
 		],
 
 		'hooks' => [],

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -23,8 +23,6 @@ class RouteServiceProvider extends ServiceProvider
 	 */
 	public function boot()
 	{
-		//
-
 		parent::boot();
 	}
 
@@ -36,13 +34,8 @@ class RouteServiceProvider extends ServiceProvider
 	public function map()
 	{
 		$this->mapApiRoutes();
-
 		$this->mapWebRoutes();
-
 		$this->mapWebHookRoutes();
-
-		$this->mapPapiRoutes();
-
 		$this->mapPapi2Routes();
 	}
 
@@ -79,14 +72,15 @@ class RouteServiceProvider extends ServiceProvider
 	{
 		Route::group([
 			'middleware' => 'api',
-			'namespace'  => $this->namespace,
-			'prefix'     => 'api/v1',
+			'namespace' => $this->namespace,
+			'prefix' => 'api/v1',
 		], function ($router) {
 			require base_path('routes/api.php');
 		});
 	}
 
-	private function mapWebHookRoutes() {
+	private function mapWebHookRoutes()
+	{
 		Route::group([
 			'middleware' => 'hooks',
 			'namespace' => $this->namespace,
@@ -95,18 +89,8 @@ class RouteServiceProvider extends ServiceProvider
 		});
 	}
 
-	// TODO remove after 01.01.2019
-	private function mapPapiRoutes() {
-		Route::group([
-			'middleware' => 'papi',
-			'namespace' => $this->namespace,
-			'prefix' => 'papi/v1',
-		], function ($router) {
-			require base_path('routes/papi.php');
-		});
-	}
-
-	private function mapPapi2Routes() {
+	private function mapPapi2Routes()
+	{
 		Route::group([
 			'middleware' => 'papi',
 			'namespace' => $this->namespace,

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"type": "project",
 	"require": {
 		"php": ">=7.3.2",
+		"barryvdh/laravel-cors": "^0.11.3",
 		"barryvdh/laravel-dompdf": "^0.8.0",
 		"bethink/elastic-scout": "3.0.8",
 		"bschmitt/laravel-amqp": "^1.2",
@@ -20,8 +21,8 @@
 		"league/flysystem-aws-s3-v3": "^1.0",
 		"league/fractal": "^0.15.0",
 		"nao-pon/flysystem-google-drive": "~1.1",
-		"rap2hpoutre/fast-excel": "^1.1",
 		"predis/predis": "^1.1",
+		"rap2hpoutre/fast-excel": "^1.1",
 		"sentry/sentry": "^1.10",
 		"symfony/css-selector": "3.1.*",
 		"symfony/dom-crawler": "3.1.*"
@@ -33,7 +34,7 @@
 		"fzaninotto/faker": "~1.4",
 		"johnkary/phpunit-speedtrap": "^3.0",
 		"laravel/dusk": "^5.0",
-		"mockery/mockery": "^1.2",
+		"mockery/mockery": "0.9.11",
 		"nunomaduro/larastan": "^0.3.15",
 		"phpunit/phpunit": "^7.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,60 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19e6b49fc925137c2542bada2b193a19",
+    "content-hash": "95f7d1a9c76424c6a7b927dc1b88a282",
     "packages": [
+        {
+            "name": "asm89/stack-cors",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/asm89/stack-cors.git",
+                "reference": "c163e2b614550aedcf71165db2473d936abbced6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/asm89/stack-cors/zipball/c163e2b614550aedcf71165db2473d936abbced6",
+                "reference": "c163e2b614550aedcf71165db2473d936abbced6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/http-foundation": "~2.7|~3.0|~4.0",
+                "symfony/http-kernel": "~2.7|~3.0|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8.10",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Asm89\\Stack\\": "src/Asm89/Stack/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander",
+                    "email": "iam.asm89@gmail.com"
+                }
+            ],
+            "description": "Cross-origin resource sharing library and stack middleware",
+            "homepage": "https://github.com/asm89/stack-cors",
+            "keywords": [
+                "cors",
+                "stack"
+            ],
+            "time": "2017-12-20T14:37:45+00:00"
+        },
         {
             "name": "aws/aws-sdk-php",
             "version": "3.87.17",
@@ -87,6 +139,68 @@
                 "sdk"
             ],
             "time": "2019-02-22T19:34:32+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-cors",
+            "version": "v0.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-cors.git",
+                "reference": "c95ac944f2f20a17949aae6645692dfd3b402bca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-cors/zipball/c95ac944f2f20a17949aae6645692dfd3b402bca",
+                "reference": "c95ac944f2f20a17949aae6645692dfd3b402bca",
+                "shasum": ""
+            },
+            "require": {
+                "asm89/stack-cors": "^1.2",
+                "illuminate/support": "5.5.x|5.6.x|5.7.x|5.8.x",
+                "php": ">=7",
+                "symfony/http-foundation": "^3.1|^4",
+                "symfony/http-kernel": "^3.1|^4"
+            },
+            "require-dev": {
+                "laravel/framework": "^5.5",
+                "orchestra/testbench": "3.3.x|3.4.x|3.5.x|3.6.x|3.7.x",
+                "phpunit/phpunit": "^4.8|^5.2|^7.0",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Cors\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\Cors\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Adds CORS (Cross-Origin Resource Sharing) headers support in your Laravel application",
+            "keywords": [
+                "api",
+                "cors",
+                "crossdomain",
+                "laravel"
+            ],
+            "time": "2019-02-26T18:08:30+00:00"
         },
         {
             "name": "barryvdh/laravel-dompdf",
@@ -5283,7 +5397,6 @@
                     "name": "Barry vd. Heuvel",
                     "email": "barryvdh@gmail.com"
                 }
-          
             ],
             "description": "PHP Debugbar integration for Laravel",
             "keywords": [

--- a/config/api.php
+++ b/config/api.php
@@ -2,6 +2,7 @@
 
 return [
 	'resources' => [
-		'coupons' => 'coupons'
+		'coupons' => 'coupons',
+		'products' => 'products',
 	],
 ];

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+	/*
+  |--------------------------------------------------------------------------
+  | Laravel CORS
+  |--------------------------------------------------------------------------
+  |
+  | allowedOrigins, allowedHeaders and allowedMethods can be set to array('*')
+  | to accept any value.
+  |
+  */
+
+	'supportsCredentials' => false,
+	'allowedOrigins' => [
+		'http://wiecejnizlek.pl',
+		'https://wiecejnizlek.pl',
+		'https://bethink.staging.wpengine.com'
+	],
+	'allowedOriginsPatterns' => [],
+	'allowedHeaders' => ['*'],
+	'allowedMethods' => ['*'],
+	'exposedHeaders' => [],
+	'maxAge' => 0,
+];

--- a/config/cors.php
+++ b/config/cors.php
@@ -21,5 +21,5 @@ return [
 	'allowedHeaders' => ['*'],
 	'allowedMethods' => ['*'],
 	'exposedHeaders' => [],
-	'maxAge' => 0,
+	'maxAge' => 600,
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,20 +19,15 @@ Route::group(['namespace' => 'Api\PublicApi'], function () {
 	Route::group([
 		'middleware' => [
 			'throttle:200,1',
+			HandleCors::class,
 		]
 	], function () use ($r) {
 		// Products
 		Route::get("{$r['products']}/current", 'ProductsApiController@getCurrent');
 	});
 
-	Route::group([
-		'middleware' => [
-			HandleCors::class,
-		]
-	], function () use ($r) {
-		// Coupons
-		Route::post("{$r['coupons']}", 'CouponsApiController@post');
-		Route::put("{$r['coupons']}", 'CouponsApiController@put');
-		Route::delete("{$r['coupons']}", 'CouponsApiController@deleteCoupon');
-	});
+	// Coupons
+	Route::post("{$r['coupons']}", 'CouponsApiController@post');
+	Route::put("{$r['coupons']}", 'CouponsApiController@put');
+	Route::delete("{$r['coupons']}", 'CouponsApiController@deleteCoupon');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,15 +11,28 @@
 |
 */
 
+use Barryvdh\Cors\HandleCors;
+
 Route::group(['namespace' => 'Api\PublicApi'], function () {
 	$r = config('api.resources');
 
-	// Products
-	Route::get('products/current', 'ProductsApiController@getCurrent');
+	Route::group([
+		'middleware' => [
+			'throttle:200,1',
+		]
+	], function () use ($r) {
+		// Products
+		Route::get("{$r['products']}/current", 'ProductsApiController@getCurrent');
+	});
 
-	// Coupons
-	Route::post("{$r['coupons']}", 'CouponsApiController@post');
-	Route::put("{$r['coupons']}", 'CouponsApiController@put');
-	Route::delete("{$r['coupons']}", 'CouponsApiController@deleteCoupon');
-
+	Route::group([
+		'middleware' => [
+			HandleCors::class,
+		]
+	], function () use ($r) {
+		// Coupons
+		Route::post("{$r['coupons']}", 'CouponsApiController@post');
+		Route::put("{$r['coupons']}", 'CouponsApiController@put');
+		Route::delete("{$r['coupons']}", 'CouponsApiController@deleteCoupon');
+	});
 });


### PR DESCRIPTION
Works fine in console on https://bethink.staging.wpengine.com/ and https://wiecejnizlek.pl/
```
let x = await fetch("https://lek.wiecejnizlek.pl/api/v1/products/current");

Access to fetch at 'https://lek.wiecejnizlek.pl/api/v1/products/current' from origin 'https://wiecejnizlek.pl' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```

```
let x = await fetch("https://staging.wiecejnizlek.pl/api/v1/products/current");
let y = await x.json();
y.find(product => product.slug === 'wnl-online').quantity;

674
```