### PR TITLE
Use queue:listen so we don't have to restart workers after code change

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,7 @@ services:
       dockerfile: Dockerfile.dev.php
     volumes:
       - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
-    command: ${CONTAINER_CODE_PATH}/wnl-platform/artisan queue:work --queue=default --tries=3 --daemon
+    command: ${CONTAINER_CODE_PATH}/wnl-platform/artisan queue:listen --queue=default --tries=3 --daemon
     depends_on:
       - redis
 
@@ -63,7 +63,7 @@ services:
       dockerfile: Dockerfile.dev.php
     volumes:
       - ${LOCAL_CODE_PATH}:${CONTAINER_CODE_PATH}
-    command: ${CONTAINER_CODE_PATH}/wnl-platform/artisan queue:work --queue=notifications --tries=3 --daemon
+    command: ${CONTAINER_CODE_PATH}/wnl-platform/artisan queue:listen --queue=notifications --tries=3 --daemon
     depends_on:
       - redis
 


### PR DESCRIPTION
Quoting https://divinglaravel.com/queue-workers-how-they-work:

> The `queue:listen` command simply runs the `queue:work --once` command inside an infinite loop, this will cause the following:
> 
> - An instance of the app is booted up on every loop.
> - The assigned worker will pick a single job and execute it.
> - The worker process will be killed.
> 
> Using `queue:listen` ensures that a new instance of the app is created for every job, that means you don't have to manually restart the worker in case you made changes to your code, but also means more server resources will be consumed.